### PR TITLE
Handle newlines between imports

### DIFF
--- a/import-sort.cabal
+++ b/import-sort.cabal
@@ -21,6 +21,7 @@ library
   build-depends:       base >= 4.7 && < 5
                      , attoparsec
                      , text
+                     , split
   default-language:    Haskell2010
 
 executable import-sort

--- a/src/ImportSort/Parser.hs
+++ b/src/ImportSort/Parser.hs
@@ -4,20 +4,36 @@ module ImportSort.Parser
     ( parseImports
     ) where
 
+import           Control.Applicative ((<|>))
 import           Data.Attoparsec.Text
+import           Data.Text (Text)
 import qualified Data.Text as T
-import           ImportSort.Types (ModuleImport(ModuleImport))
+import           ImportSort.Types (ModuleImport(..))
 
 parseImports :: String -> Either String [ModuleImport]
 parseImports = parseOnly (importsParser <* endOfInput) . T.pack
 
 importsParser :: Parser [ModuleImport]
-importsParser = many' $ moduleImportParser <* endOfLine
+importsParser = many' moduleImportParser
 
 moduleImportParser :: Parser ModuleImport
 moduleImportParser =
-    "import" *> skipSpace *> (
-        ModuleImport
-        <$> option False (const True <$> string "qualified") <* skipSpace
-        <*> takeTill isEndOfLine
-        )
+    qualifiedImportParser
+    <|> nonQualifiedImportParser
+    <|> separatorParser
+
+qualifiedImportParser :: Parser ModuleImport
+qualifiedImportParser = do
+    "import" *> skipSpace *> "qualified" *> skipSpace
+    QualifiedImport <$> importTextParser <* endOfLine
+
+nonQualifiedImportParser :: Parser ModuleImport
+nonQualifiedImportParser = do
+    "import" *> skipSpace
+    NonQualifiedImport <$> importTextParser <* endOfLine
+
+separatorParser :: Parser ModuleImport
+separatorParser = endOfLine *> pure Separator
+
+importTextParser :: Parser Text
+importTextParser = takeTill isEndOfLine

--- a/src/ImportSort/Sort.hs
+++ b/src/ImportSort/Sort.hs
@@ -5,7 +5,7 @@ module ImportSort.Sort
 import qualified Data.List as L
 import qualified Data.Text as T
 import qualified ImportSort.Parser as P
-import           ImportSort.Types (ModuleImport(ModuleImport), sortedImports)
+import           ImportSort.Types
 
 sortImport :: String -> String
 sortImport s =
@@ -15,14 +15,14 @@ renderImports :: [ModuleImport] -> [String]
 renderImports is =
     map (renderImport anyQualified) is
   where
-    anyQualified = any qualifiedPresent is
-    qualifiedPresent (ModuleImport v _) = v
+    anyQualified = any miQualified is
 
 renderImport :: Bool -> ModuleImport -> String
-renderImport anyQualified (ModuleImport qualified value) =
-    "import " ++ qual ++ T.unpack value
+renderImport _ Separator = ""
+renderImport anyQualified mi =
+    "import " ++ qual ++ T.unpack (miValue mi)
   where
-    qual = case (anyQualified, qualified) of
+    qual = case (anyQualified, miQualified mi) of
         (False, _) -> ""
         (_, True)  -> "qualified "
         (_, False) -> "          "

--- a/src/ImportSort/Types.hs
+++ b/src/ImportSort/Types.hs
@@ -1,15 +1,36 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module ImportSort.Types
-    ( ModuleImport(ModuleImport)
+    ( ModuleImport(..)
     , sortedImports
+    , miValue
+    , miQualified
     ) where
 
-import           Data.Text (Text)
 import qualified Data.List as L
+import qualified Data.List.Split as LS
+import           Data.Text (Text)
 
-data ModuleImport = ModuleImport Bool Text
+data ModuleImport
+    = QualifiedImport Text
+    | NonQualifiedImport Text
+    | Separator
+    deriving Eq
 
 sortedImports :: [ModuleImport] -> [ModuleImport]
-sortedImports = L.sortBy sortModuleImport
+sortedImports = concatMap sortedImports' . splitOn [Separator]
+  where
+    sortedImports' = L.sortBy sortModuleImport
+    splitOn = LS.split . LS.onSublist
 
 sortModuleImport :: ModuleImport -> ModuleImport -> Ordering
-sortModuleImport (ModuleImport _ a) (ModuleImport _ b) = compare a b
+sortModuleImport a b = compare (miValue a) (miValue b)
+
+miValue :: ModuleImport -> Text
+miValue (QualifiedImport t) = t
+miValue (NonQualifiedImport t) = t
+miValue Separator = ""
+
+miQualified :: ModuleImport -> Bool
+miQualified (QualifiedImport _) = True
+miQualified _ = False

--- a/test/ImportSort/SortSpec.hs
+++ b/test/ImportSort/SortSpec.hs
@@ -31,6 +31,16 @@ spec = parallel $
                         "import Data.Bifunctor (first)\n\
                         \import Data.List ((++))"
 
+        it "retains newlines as separators" $ do
+            let string = "import Data.Maybe (catMaybes)\n\
+                         \import Data.List ((++))\n\n\
+                         \import qualified Data.Bifunctor as BF\n"
+
+            S.sortImport string `shouldBe`
+                        "import           Data.List ((++))\n\
+                        \import           Data.Maybe (catMaybes)\n\n\
+                        \import qualified Data.Bifunctor as BF"
+
         it "returns the original string if parsing failed" $ do
             let string = "import qualified Data.List as L\nfoo\n"
 


### PR DESCRIPTION
Developers may want to separate imports into logical groups; this
retains grouping, sorting each sub-group accordingly.

Sorting:

```
import qualified Data.Maybe as M
import qualified Data.List as L
import Data.Bool (bool)

import Control.Monad (void)
import Control.Applicative ((<|>))
```

Would result in:

```
import           Data.Bool (bool)
import qualified Data.List as L
import qualified Data.Maybe as M

import           Control.Applicative ((<|>))
import           Control.Monad (void)
```
