### PR TITLE
Allow running import-sort on entire Haskell file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ ImportSort is a utility to format and sort Haskell imports alphabetically.
 
 ## Supported Behavior
 
-ImportSort correctly handles one or many single-line imports.
+ImportSort correctly handles one or many **single-line imports**.
 
 It sorts and aligns imports correctly:
 
@@ -36,21 +36,6 @@ import           Data.Maybe (catMaybes)
 -- | new
 import Data.List ((++))
 import Data.Maybe (catMaybes)
-```
-
-If import-sort cannot parse the list of imports, the value is returned
-unchanged:
-
-```haskell
--- | old
-import           Data.List ((++))
--- | TODO: do something
-import           Data.Maybe (catMaybes)
-
--- | new
-import           Data.List ((++))
--- | TODO: do something
-import           Data.Maybe (catMaybes)
 ```
 
 ## Installation
@@ -106,7 +91,7 @@ against visually-selected text this should still work.
 I use the following [keyboard shortcut](https://github.com/joshuaclayton/nvim-config/commit/9e2e4e2980fee69496ea4138bab9a37cf41c001c):
 
 ```vimscript
-vmap <silent> <C-I> :!import-sort<CR>
+map <Leader><C-I> :%!import-sort<CR>
 ```
 
 Create a visual selection across whatever imports you want to sort (`Shift-v`,

--- a/src/ImportSort/Parser.hs
+++ b/src/ImportSort/Parser.hs
@@ -24,16 +24,16 @@ moduleImportParser =
 
 qualifiedImportParser :: Parser ModuleImport
 qualifiedImportParser = do
-    "import" *> skipSpace *> "qualified" *> skipSpace
-    QualifiedImport <$> importTextParser <* endOfLine
+    "import " *> skipSpace *> "qualified" *> skipSpace
+    QualifiedImport <$> toEol
 
 nonQualifiedImportParser :: Parser ModuleImport
 nonQualifiedImportParser = do
-    "import" *> skipSpace
-    NonQualifiedImport <$> importTextParser <* endOfLine
+    "import " *> skipSpace
+    NonQualifiedImport <$> toEol
 
 separatorParser :: Parser ModuleImport
-separatorParser = endOfLine *> pure Separator
+separatorParser = Separator <$> toEol
 
-importTextParser :: Parser Text
-importTextParser = takeTill isEndOfLine
+toEol :: Parser Text
+toEol = takeTill isEndOfLine <* endOfLine

--- a/src/ImportSort/Sort.hs
+++ b/src/ImportSort/Sort.hs
@@ -18,7 +18,7 @@ renderImports is =
     anyQualified = any miQualified is
 
 renderImport :: Bool -> ModuleImport -> String
-renderImport _ Separator = ""
+renderImport _ (Separator t) = T.unpack t
 renderImport anyQualified mi =
     "import " ++ qual ++ T.unpack (miValue mi)
   where

--- a/src/ImportSort/Types.hs
+++ b/src/ImportSort/Types.hs
@@ -14,14 +14,16 @@ import           Data.Text (Text)
 data ModuleImport
     = QualifiedImport Text
     | NonQualifiedImport Text
-    | Separator
+    | Separator Text
     deriving Eq
 
 sortedImports :: [ModuleImport] -> [ModuleImport]
-sortedImports = concatMap sortedImports' . splitOn [Separator]
+sortedImports = concatMap sortedImports' . splitOn separators
   where
     sortedImports' = L.sortBy sortModuleImport
-    splitOn = LS.split . LS.onSublist
+    splitOn = LS.split . LS.whenElt
+    separators (Separator _) = True
+    separators _ = False
 
 sortModuleImport :: ModuleImport -> ModuleImport -> Ordering
 sortModuleImport a b = compare (miValue a) (miValue b)
@@ -29,7 +31,7 @@ sortModuleImport a b = compare (miValue a) (miValue b)
 miValue :: ModuleImport -> Text
 miValue (QualifiedImport t) = t
 miValue (NonQualifiedImport t) = t
-miValue Separator = ""
+miValue (Separator t) = t
 
 miQualified :: ModuleImport -> Bool
 miQualified (QualifiedImport _) = True

--- a/test/ImportSort/SortSpec.hs
+++ b/test/ImportSort/SortSpec.hs
@@ -1,7 +1,7 @@
 module ImportSort.SortSpec where
 
-import           Test.Hspec
 import qualified ImportSort.Sort as S
+import           Test.Hspec
 
 main :: IO ()
 main = hspec spec
@@ -41,7 +41,27 @@ spec = parallel $
                         \import           Data.Maybe (catMaybes)\n\n\
                         \import qualified Data.Bifunctor as BF"
 
+        it "allows for full file context" $ do
+            let string = "module Awesome where\n\n\
+                         \import Data.Maybe (catMaybes)\n\
+                         \import Data.List ((++))\n\n\
+                         \import qualified Data.Bifunctor as BF\n\n\
+                         \link :: Int\n\
+                         \link = 1\n\n\
+                         \importPrefixedFunction :: Int\n\
+                         \importPrefixedFunction = 2\n"
+
+            S.sortImport string `shouldBe`
+                        "module Awesome where\n\n\
+                        \import           Data.List ((++))\n\
+                        \import           Data.Maybe (catMaybes)\n\n\
+                        \import qualified Data.Bifunctor as BF\n\n\
+                        \link :: Int\n\
+                        \link = 1\n\n\
+                        \importPrefixedFunction :: Int\n\
+                        \importPrefixedFunction = 2"
+
         it "returns the original string if parsing failed" $ do
-            let string = "import qualified Data.List as L\nfoo\n"
+            let string = "import qualified Data.List as L\nfoo"
 
             S.sortImport string `shouldBe` string


### PR DESCRIPTION
This allows an entire file to be run through import-sort, retaining
ordering of everything other than imports.

This continues to work only with single-line imports.
